### PR TITLE
adds acceptcharset to logs schema

### DIFF
--- a/tinybird/datasources/logs.datasource
+++ b/tinybird/datasources/logs.datasource
@@ -1,6 +1,7 @@
 TOKEN logger APPEND
 
 SCHEMA >
+    `acceptcharset` String `json:$.acceptcharset`,
     `acceptencoding` String `json:$.acceptencoding`,
     `acceptlanguage` String `json:$.acceptlanguage`,
     `browsername` String `json:$.browsername`,


### PR DESCRIPTION
Adds `acceptcharset` to the DS schema

```
`acceptcharset` String `json:$.acceptcharset` ,
```