### PR TITLE
Use a single token for read/write

### DIFF
--- a/tinybird/datasources/logs.datasource
+++ b/tinybird/datasources/logs.datasource
@@ -1,4 +1,5 @@
-TOKEN logger APPEND
+TOKEN app APPEND
+TOKEN app CREATE
 
 SCHEMA >
     `acceptcharset` String `json:$.acceptcharset`,

--- a/tinybird/endpoints/average_calls_per_ip_api.pipe
+++ b/tinybird/endpoints/average_calls_per_ip_api.pipe
@@ -1,4 +1,4 @@
-TOKEN dashboard READ
+TOKEN app READ
 
 NODE merge
 SQL >

--- a/tinybird/endpoints/average_error_count_api.pipe
+++ b/tinybird/endpoints/average_error_count_api.pipe
@@ -1,4 +1,4 @@
-TOKEN dashboard READ
+TOKEN app READ
 
 NODE total_errors_per_function
 SQL >

--- a/tinybird/endpoints/error_frequency_api.pipe
+++ b/tinybird/endpoints/error_frequency_api.pipe
@@ -1,4 +1,4 @@
-TOKEN dashboard READ
+TOKEN app READ
 
 NODE endpoint
 SQL >

--- a/tinybird/endpoints/error_per_api.pipe
+++ b/tinybird/endpoints/error_per_api.pipe
@@ -1,4 +1,4 @@
-TOKEN dashboard READ
+TOKEN app READ
 
 NODE endpoint
 SQL >

--- a/tinybird/endpoints/function_errors_api.pipe
+++ b/tinybird/endpoints/function_errors_api.pipe
@@ -1,4 +1,4 @@
-TOKEN dashboard READ
+TOKEN app READ
 
 NODE endpoint
 SQL >

--- a/tinybird/endpoints/ips_exceeding_avg_calls_per_minute_api.pipe
+++ b/tinybird/endpoints/ips_exceeding_avg_calls_per_minute_api.pipe
@@ -1,4 +1,4 @@
-TOKEN dashboard READ
+TOKEN app READ
 
 NODE merge
 SQL >

--- a/tinybird/endpoints/ips_with_most_calls_api.pipe
+++ b/tinybird/endpoints/ips_with_most_calls_api.pipe
@@ -1,4 +1,4 @@
-TOKEN dashboard READ
+TOKEN app READ
 
 NODE endpoint
 SQL >

--- a/tinybird/endpoints/log_level_frequency_api.pipe
+++ b/tinybird/endpoints/log_level_frequency_api.pipe
@@ -1,4 +1,4 @@
-TOKEN dashboard READ
+TOKEN app READ
 
 NODE endpoint
 SQL >

--- a/tinybird/endpoints/top_functions_api.pipe
+++ b/tinybird/endpoints/top_functions_api.pipe
@@ -1,4 +1,4 @@
-TOKEN dashboard READ
+TOKEN app READ
 
 NODE endpoint
 SQL >


### PR DESCRIPTION
To make it easier to onboard, changes the logger+dashboard token into a single 'app' token that has both read/write. It's not best practise, but it's useful to reduce the amount of steps & docs required to onboard a new user onto the starter kit.